### PR TITLE
Bump up ethereum-ibc-relay-chain to v0.3.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.5
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-go/v8 v8.2.0
-	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.2
+	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.4
 	github.com/ethereum/go-ethereum v1.13.15
 	github.com/hyperledger-labs/yui-relayer v0.5.3
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -415,8 +415,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.2 h1:obAxG44znqLUY0wpsTeRrWlQ/A6ls0uYLL1USEM5nko=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.2/go.mod h1:PdSsegkRJiMWVGq+afDtXKRKg4p8hnmR1Yj5BgXkit0=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.4 h1:2mbvy6W/lm11SeQBgj1100A6D/70Wk9DooMoZfE8oXU=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.4/go.mod h1:PdSsegkRJiMWVGq+afDtXKRKg4p8hnmR1Yj5BgXkit0=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
https://github.com/datachainlab/cosmos-ethereum-ibc-lcp/releases/tag/v0.2.1