### PR TITLE
Suppress development log

### DIFF
--- a/module/constant/development.go
+++ b/module/constant/development.go
@@ -18,5 +18,7 @@ func init() {
 		panic(err)
 	}
 	BlocksPerEpoch = uint64(iBlocksPerEpoch)
-	log.Printf("blocks per epoch = %d", BlocksPerEpoch)
+	if BlocksPerEpoch != 200 {
+		log.Printf("blocks per epoch = %d", BlocksPerEpoch)
+	}
 }


### PR DESCRIPTION
print log only when blocks per epoch is not default.