### PR TITLE
Log for error of Fast Finality

### DIFF
--- a/module/setup.go
+++ b/module/setup.go
@@ -128,7 +128,9 @@ func setupNonNeighboringEpochHeader(
 	}
 	if !trustedValidatorSet.Contains(currentValidatorSet) {
 		// It is recommended to recreate the Client.
-		return nil, fmt.Errorf("setupNonNeighboringEpochHeader: invalid untrusted validator set: epochHeight=%d, trustedEpochHeight=%d", epochHeight, trustedEpochHeight)
+		err = fmt.Errorf("setupNonNeighboringEpochHeader: invalid untrusted validator set: epochHeight=%d, trustedEpochHeight=%d", epochHeight, trustedEpochHeight)
+		log.GetLogger().Error("[FastFinalityError]", err)
+		return nil, err
 	}
 
 	// ex) trusted(prevSaved = 200), epochHeight = 600 must be finalized from 611 to min(810,latest)


### PR DESCRIPTION
Even for non-adjacent Epoch validation, it is an error if it does not contain 1/3 of the trusted validator set. Therefore, logs are output.