### PR TITLE
Use cons.GetTimestamp() as nsec

### DIFF
--- a/module/prover.go
+++ b/module/prover.go
@@ -180,9 +180,7 @@ func (pr *Prover) CheckRefreshRequired(counterparty core.ChainInfoICS02Querier) 
 	if err = pr.chain.Codec().UnpackAny(resCons.ConsensusState, &cons); err != nil {
 		return false, fmt.Errorf("failed to unpack Any into tendermint consensus state: %+v", err)
 	}
-
-	// cons.GetTimestamp() returns not nsec but sec
-	lcLastTimestamp := time.Unix(int64(cons.GetTimestamp()), 0)
+	lcLastTimestamp := time.Unix(0, int64(cons.GetTimestamp()))
 
 	selfQueryHeight, err := pr.chain.LatestHeight()
 	if err != nil {

--- a/module/prover_test.go
+++ b/module/prover_test.go
@@ -531,13 +531,13 @@ func (ts *ProverTestSuite) TestCheckRefreshRequired() {
 	csHeight := clienttypes.NewHeight(0, ts.chain.clientStateLatestHeight)
 
 	// should refresh
-	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-51 * time.Second).Unix())
+	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-51 * time.Second).UnixNano())
 	required, err := ts.prover.CheckRefreshRequired(dst)
 	ts.Require().NoError(err)
 	ts.Require().True(required)
 
 	// needless
-	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-50 * time.Second).Unix())
+	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-50 * time.Second).UnixNano())
 	required, err = ts.prover.CheckRefreshRequired(dst)
 	ts.Require().NoError(err)
 	ts.Require().False(required)


### PR DESCRIPTION
This PR is patch release for latest tag(v0.2.2)
v0.2.3 will be published after merge.
