### PR TITLE
Remove checking trusted validator in relayer

### DIFF
--- a/e2e/chains/bsc/docker-compose.bsc.yml
+++ b/e2e/chains/bsc/docker-compose.bsc.yml
@@ -5,5 +5,5 @@ services:
       dockerfile: Dockerfile.bsc
       args:
         GIT_SOURCE: https://github.com/bnb-chain/bsc
-        GIT_CHECKOUT_BRANCH: v1.4.13
+        GIT_CHECKOUT_BRANCH: v1.4.16
     image: bsc-geth:docker-local

--- a/e2e/contracts/package-lock.json
+++ b/e2e/contracts/package-lock.json
@@ -2671,6 +2671,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
       "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "catering": "^2.0.0",
@@ -3681,6 +3682,7 @@
       "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
       "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -4516,6 +4518,7 @@
       "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.4.1.tgz",
       "integrity": "sha512-r4eRSeStEGf6M5SKdrQhhLK5bOwOBxQhIE3YSTnZE3GpKiLfnnhE+tPtrJE79+eDJgm39BM6LSoI8SCx4HbwlQ==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -10413,6 +10416,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "engines": {
         "node": ">=4"
       }
@@ -10907,6 +10911,7 @@
       "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
       "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "catering": "^2.1.0"
       },
@@ -11039,6 +11044,7 @@
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
       "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -11111,6 +11117,7 @@
       "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "abstract-leveldown": "~6.2.1",
         "napi-macros": "~2.0.0",
@@ -11125,6 +11132,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.3.tgz",
       "integrity": "sha512-BsLm5vFMRUrrLeCcRc+G0t2qOaTzpoJQLOubq2XM72eNpjF5UdU5o/5NvlNhx95XHcAvcl8OMXr4mlg/fRgUXQ==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "immediate": "^3.2.3",
@@ -11155,6 +11163,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -11165,6 +11174,7 @@
       "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
       "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -11174,6 +11184,7 @@
       "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
       "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
       "dev": true,
+      "optional": true,
       "dependencies": {
         "xtend": "^4.0.2"
       },
@@ -11186,6 +11197,7 @@
       "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
       "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ==",
       "dev": true,
+      "optional": true,
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -12081,7 +12093,8 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
       "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -13185,7 +13198,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "optional": true
     },
     "node_modules/quick-lru": {
       "version": "5.1.1",

--- a/module/setup.go
+++ b/module/setup.go
@@ -61,21 +61,10 @@ func setupNeighboringEpochHeader(
 	if err != nil {
 		return nil, fmt.Errorf("setupNeighboringEpochHeader: failed to get current validator set: epochHeight=%d : %+v", epochHeight, err)
 	}
-	trustedValidatorSet, trustedTurnLength, err := queryValidatorSetAndTurnLength(getHeader, trustedEpochHeight)
-	if err != nil {
-		return nil, fmt.Errorf("setupNeighboringEpochHeader: failed to get trusted validator set: trustedEpochHeight=%d : %+v", trustedEpochHeight, err)
-	}
-	if trustedValidatorSet.Contains(currentValidatorSet) {
-		// ex) trusted(prevSaved = 200), epochHeight = 400 must be finalized by min(610,latest)
-		nextCheckpoint := currentValidatorSet.Checkpoint(currentTurnLength) + (epochHeight + constant.BlocksPerEpoch)
-		limit := minUint64(nextCheckpoint-1, latestHeight.GetRevisionHeight())
-		return queryVerifiableHeader(epochHeight, limit)
-	} else {
-		// ex) trusted(prevSaved = 200), epochHeight = 400 must be finalized by min(410,latest)
-		checkpoint := trustedValidatorSet.Checkpoint(trustedTurnLength) + epochHeight
-		limit := minUint64(checkpoint-1, latestHeight.GetRevisionHeight())
-		return queryVerifiableHeader(epochHeight, limit)
-	}
+	// ex) trusted(prevSaved = 200), epochHeight = 400 must be finalized by min(610,latest)
+	nextCheckpoint := currentValidatorSet.Checkpoint(currentTurnLength) + (epochHeight + constant.BlocksPerEpoch)
+	limit := minUint64(nextCheckpoint-1, latestHeight.GetRevisionHeight())
+	return queryVerifiableHeader(epochHeight, limit)
 }
 
 func withTrustedHeight(targetHeaders []core.Header, clientStateLatestHeight exported.Height) []core.Header {

--- a/module/setup_test.go
+++ b/module/setup_test.go
@@ -139,45 +139,7 @@ func (ts *SetupTestSuite) TestSuccess_setupHeadersForUpdate_allEmpty() {
 	verify(constant.BlocksPerEpoch+1, 10*constant.BlocksPerEpoch+1, 0) // non neighboring
 }
 
-func (ts *SetupTestSuite) TestSuccess_setupNeighboringEpochHeader_notContainTrusted() {
-
-	epochHeight := uint64(400)
-	trustedEpochHeight := uint64(200)
-
-	neighboringEpochFn := func(height uint64, limit uint64) (core.Header, error) {
-		target, err := newETHHeader(&types2.Header{
-			Number: big.NewInt(int64(limit)),
-		})
-		ts.Require().NoError(err)
-		return &Header{
-			Headers: []*ETHHeader{target},
-		}, nil
-	}
-	headerFn := func(_ context.Context, height uint64) (*types2.Header, error) {
-		h := headerByHeight(int64(height))
-		const validatorCount = 4
-		const indexOfValidatorCount = extraVanity
-		const indexOfTurnLength = extraVanity + validatorNumberSize + validatorCount*validatorBytesLength
-		if h.Number.Uint64() == trustedEpochHeight {
-			// set invalid validator
-			for i := range h.Extra {
-				if i != indexOfValidatorCount && i != indexOfTurnLength {
-					h.Extra[i] = 0
-				}
-			}
-		}
-		return h, nil
-	}
-	hs, err := setupNeighboringEpochHeader(headerFn, neighboringEpochFn, epochHeight, trustedEpochHeight, clienttypes.NewHeight(0, 10000))
-	ts.Require().NoError(err)
-	target, err := hs.(*Header).Target()
-	ts.Require().NoError(err)
-
-	// checkpoint - 1
-	ts.Require().Equal(int64(402), target.Number.Int64())
-}
-
-func (ts *SetupTestSuite) TestSuccess_setupNeighboringEpochHeader_containTrusted() {
+func (ts *SetupTestSuite) TestSuccess_setupNeighboringEpochHeader() {
 
 	epochHeight := uint64(400)
 	trustedEpochHeight := uint64(200)

--- a/module/validator_set.go
+++ b/module/validator_set.go
@@ -3,7 +3,6 @@ package module
 import (
 	"context"
 	"fmt"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -11,31 +10,6 @@ type Validators [][]byte
 
 func (v Validators) Checkpoint(turnLength uint8) uint64 {
 	return uint64(len(v)/2+1) * uint64(turnLength)
-}
-
-func (v Validators) Contains(other Validators) bool {
-	count := 0
-	for _, x := range other {
-		for _, y := range v {
-			if common.Bytes2Hex(x) == common.Bytes2Hex(y) {
-				count++
-				break
-			}
-		}
-	}
-	required := v.threshold()
-	return count >= required
-}
-
-func (v Validators) threshold() int {
-	return len(v) - ceilDiv(len(v)*2, 3) + 1
-}
-
-func ceilDiv(x, y int) int {
-	if y == 0 {
-		return 0
-	}
-	return (x + y - 1) / y
 }
 
 func queryValidatorSetAndTurnLength(fn getHeaderFn, epochBlockNumber uint64) (Validators, uint8, error) {

--- a/module/validator_set_test.go
+++ b/module/validator_set_test.go
@@ -89,32 +89,3 @@ func (ts *ValidatorSetTestSuite) TestCheckpoint() {
 	ts.Equal(int(validator.Checkpoint(3)), 33)
 	ts.Equal(int(validator.Checkpoint(9)), 99)
 }
-
-func (ts *ValidatorSetTestSuite) TestTrustValidator() {
-	trusted := Validators([][]byte{{1}, {2}, {3}, {4}, {5}})
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}, {4}, {5}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}, {4}, {5}, {10}, {11}, {12}, {13}, {14}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}, {4}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}, {4}, {10}, {11}, {12}, {13}, {14}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {3}, {10}, {11}, {12}, {13}, {14}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}}))
-	ts.True(trusted.Contains([][]byte{{1}, {2}, {10}, {11}, {12}, {13}, {14}}))
-	ts.False(trusted.Contains([][]byte{{1}}))
-	ts.False(trusted.Contains([][]byte{{1}, {10}, {11}, {12}, {13}, {14}}))
-	ts.False(trusted.Contains([][]byte{}))
-	ts.False(trusted.Contains([][]byte{{10}, {11}, {12}, {13}, {14}}))
-}
-
-func (ts *ValidatorSetTestSuite) TestThreshold() {
-	ts.Equal(1, Validators(make([][]byte, 1)).threshold())
-	ts.Equal(1, Validators(make([][]byte, 2)).threshold())
-	ts.Equal(2, Validators(make([][]byte, 3)).threshold())
-	ts.Equal(2, Validators(make([][]byte, 4)).threshold())
-	ts.Equal(2, Validators(make([][]byte, 5)).threshold())
-	ts.Equal(3, Validators(make([][]byte, 6)).threshold())
-	ts.Equal(3, Validators(make([][]byte, 7)).threshold())
-	ts.Equal(3, Validators(make([][]byte, 8)).threshold())
-	ts.Equal(4, Validators(make([][]byte, 9)).threshold())
-	ts.Equal(8, Validators(make([][]byte, 21)).threshold())
-}

--- a/tool/testdata/internal/common.go
+++ b/tool/testdata/internal/common.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/datachainlab/ethereum-ibc-relay-chain/pkg/relay/ethereum"
-	"github.com/datachainlab/ethereum-ibc-relay-chain/pkg/relay/ethereum/signers/hd"
+	"github.com/datachainlab/ibc-hd-signer/pkg/hd"
 	"github.com/datachainlab/ibc-parlia-relay/module"
 	"github.com/spf13/viper"
 	"os"


### PR DESCRIPTION
The validity of the validator set is determined by the availability of the vote in the [ELC#77](https://github.com/datachainlab/parlia-elc/pull/77), so the check in the relayer is not performed.
