### PR TITLE
Use context appropriately

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cosmos/cosmos-sdk v0.50.5
 	github.com/cosmos/gogoproto v1.4.11
 	github.com/cosmos/ibc-go/v8 v8.2.1
-	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16
+	github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17
 	github.com/datachainlab/ibc-hd-signer v0.1.2
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/hyperledger-labs/yui-relayer v0.5.11

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,8 @@ github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7Do
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/danieljoos/wincred v1.1.2 h1:QLdCxFs1/Yl4zduvBdcHB8goaYk9RARS2SgLLRuAyr0=
 github.com/danieljoos/wincred v1.1.2/go.mod h1:GijpziifJoIBfYh+S7BbkdUTU4LfM+QnGqR5Vl2tAx0=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16 h1:C4xwZ1Pq5O+ITjP5UphpwThtTHnWiTe0V4pckEvqfwI=
-github.com/datachainlab/ethereum-ibc-relay-chain v0.3.16/go.mod h1:sf+ti1uM1joxhukxIyj8oDQ5yf7d+e+nl+3vtn9f5CM=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17 h1:oyDLIbc9hyp31c3OoIB5wHm51tpyDrYAu1KBA1KxfEw=
+github.com/datachainlab/ethereum-ibc-relay-chain v0.3.17/go.mod h1:sf+ti1uM1joxhukxIyj8oDQ5yf7d+e+nl+3vtn9f5CM=
 github.com/datachainlab/ibc-hd-signer v0.1.2 h1:fWAYjMBVyM390OllX/l58mZYA7we0spEBFLYKWYTwfw=
 github.com/datachainlab/ibc-hd-signer v0.1.2/go.mod h1:nwH0Z3TK/7jbu/oInGGWGRimQ+LCn6yvDyjMZrw9mR4=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/module/chain.go
+++ b/module/chain.go
@@ -16,7 +16,7 @@ type Chain interface {
 	Header(ctx context.Context, height uint64) (*types.Header, error)
 	IBCAddress() common.Address
 	CanonicalChainID(ctx context.Context) (uint64, error)
-	GetProof(address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*client.StateProof, error)
+	GetProof(ctx context.Context, address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*client.StateProof, error)
 }
 
 type ethChain struct {
@@ -47,6 +47,6 @@ func (c *ethChain) CanonicalChainID(ctx context.Context) (uint64, error) {
 	return chainID.Uint64(), nil
 }
 
-func (c *ethChain) GetProof(address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*client.StateProof, error) {
-	return c.Client().GetProof(context.TODO(), address, storageKeys, blockNumber)
+func (c *ethChain) GetProof(ctx context.Context, address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*client.StateProof, error) {
+	return c.Client().GetProof(ctx, address, storageKeys, blockNumber)
 }

--- a/module/chain.go
+++ b/module/chain.go
@@ -48,5 +48,5 @@ func (c *ethChain) CanonicalChainID(ctx context.Context) (uint64, error) {
 }
 
 func (c *ethChain) GetProof(address common.Address, storageKeys [][]byte, blockNumber *big.Int) (*client.StateProof, error) {
-	return c.Client().GetProof(address, storageKeys, blockNumber)
+	return c.Client().GetProof(context.TODO(), address, storageKeys, blockNumber)
 }

--- a/module/facade.go
+++ b/module/facade.go
@@ -1,6 +1,10 @@
 package module
 
-import "github.com/ethereum/go-ethereum/core/types"
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/core/types"
+)
 
 // Facade for tool modules
 
@@ -13,11 +17,11 @@ func GetCurrentEpoch(v uint64) uint64 {
 }
 
 func QueryFinalizedHeader(fn getHeaderFn, height uint64, limitHeight uint64) ([]*ETHHeader, error) {
-	return queryFinalizedHeader(fn, height, limitHeight)
+	return queryFinalizedHeader(context.TODO(), fn, height, limitHeight)
 }
 
 func QueryValidatorSetAndTurnLength(fn getHeaderFn, height uint64) (Validators, uint8, error) {
-	return queryValidatorSetAndTurnLength(fn, height)
+	return queryValidatorSetAndTurnLength(context.TODO(), fn, height)
 }
 
 func ExtractValidatorSetAndTurnLength(h *types.Header) (Validators, uint8, error) {

--- a/module/facade.go
+++ b/module/facade.go
@@ -16,12 +16,12 @@ func GetCurrentEpoch(v uint64) uint64 {
 	return getCurrentEpoch(v)
 }
 
-func QueryFinalizedHeader(fn getHeaderFn, height uint64, limitHeight uint64) ([]*ETHHeader, error) {
-	return queryFinalizedHeader(context.TODO(), fn, height, limitHeight)
+func QueryFinalizedHeader(ctx context.Context, fn getHeaderFn, height uint64, limitHeight uint64) ([]*ETHHeader, error) {
+	return queryFinalizedHeader(ctx, fn, height, limitHeight)
 }
 
-func QueryValidatorSetAndTurnLength(fn getHeaderFn, height uint64) (Validators, uint8, error) {
-	return queryValidatorSetAndTurnLength(context.TODO(), fn, height)
+func QueryValidatorSetAndTurnLength(ctx context.Context, fn getHeaderFn, height uint64) (Validators, uint8, error) {
+	return queryValidatorSetAndTurnLength(ctx, fn, height)
 }
 
 func ExtractValidatorSetAndTurnLength(h *types.Header) (Validators, uint8, error) {

--- a/module/header_query_test.go
+++ b/module/header_query_test.go
@@ -2,13 +2,14 @@ package module
 
 import (
 	"context"
+	"math/big"
+	"strings"
+	"testing"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger-labs/yui-relayer/log"
 	"github.com/stretchr/testify/suite"
-	"math/big"
-	"strings"
-	"testing"
 )
 
 type HeaderQueryTestSuite struct {
@@ -33,7 +34,7 @@ func (ts *HeaderQueryTestSuite) TestErrorQueryFinalizedHeader() {
 	}
 
 	// No finalized header found
-	headers, err := queryFinalizedHeader(fn, 1, 10)
+	headers, err := queryFinalizedHeader(context.Background(), fn, 1, 10)
 	ts.Require().NoError(err)
 	ts.Require().Nil(headers)
 
@@ -45,7 +46,7 @@ func (ts *HeaderQueryTestSuite) TestErrorQueryFinalizedHeader() {
 		return &types.Header{Number: big.NewInt(int64(height))}, nil
 	}
 
-	headers, err = queryFinalizedHeader(fn, 360, 400)
+	headers, err = queryFinalizedHeader(context.Background(), fn, 360, 400)
 	ts.Require().NoError(err)
 	ts.Require().Nil(headers)
 }
@@ -60,7 +61,7 @@ func (ts *HeaderQueryTestSuite) TestSuccessQueryFinalizedHeader() {
 		return &types.Header{Number: big.NewInt(int64(height))}, nil
 	}
 
-	headers, err := queryFinalizedHeader(fn, 360, 402)
+	headers, err := queryFinalizedHeader(context.Background(), fn, 360, 402)
 	ts.Require().NoError(err)
 	ts.Require().Len(headers, 402-360)
 }
@@ -75,7 +76,7 @@ func (ts *HeaderQueryTestSuite) TestSuccessQueryLatestFinalizedHeader() {
 			}
 			return &types.Header{Number: big.NewInt(int64(height))}, nil
 		}
-		height, h, err := queryLatestFinalizedHeader(getHeader, latestBlockNumber)
+		height, h, err := queryLatestFinalizedHeader(context.Background(), getHeader, latestBlockNumber)
 		ts.Require().NoError(err)
 		ts.Require().Len(h, 3)
 		ts.Require().Equal(int(height), 401)
@@ -94,7 +95,7 @@ func (ts *HeaderQueryTestSuite) TestErrorQueryLatestFinalizedHeader_NoVote() {
 				Extra:  extra,
 			}, nil
 		}
-		_, _, err := queryLatestFinalizedHeader(getHeader, latestBlockNumber)
+		_, _, err := queryLatestFinalizedHeader(context.Background(), getHeader, latestBlockNumber)
 		ts.Require().True(strings.Contains(err.Error(), "no finalized header found"))
 	}
 

--- a/module/proof.go
+++ b/module/proof.go
@@ -18,9 +18,9 @@ import (
 	"github.com/ethereum/go-ethereum/trie"
 )
 
-func (pr *Prover) getAccountProof(height uint64) ([]byte, common.Hash, error) {
+func (pr *Prover) getAccountProof(ctx context.Context, height uint64) ([]byte, common.Hash, error) {
 	stateProof, err := pr.chain.GetProof(
-		context.TODO(),
+		ctx,
 		pr.chain.IBCAddress(),
 		nil,
 		big.NewInt(0).SetUint64(height),
@@ -31,7 +31,7 @@ func (pr *Prover) getAccountProof(height uint64) ([]byte, common.Hash, error) {
 	return stateProof.AccountProofRLP, common.BytesToHash(stateProof.StorageHash[:]), nil
 }
 
-func (pr *Prover) getStateCommitmentProof(path []byte, height exported.Height) ([]byte, []byte, error) {
+func (pr *Prover) getStateCommitmentProof(ctx context.Context, path []byte, height exported.Height) ([]byte, []byte, error) {
 	// calculate slot for commitment
 	storageKey := crypto.Keccak256Hash(append(
 		crypto.Keccak256Hash(path).Bytes(),
@@ -44,7 +44,7 @@ func (pr *Prover) getStateCommitmentProof(path []byte, height exported.Height) (
 
 	// call eth_getProof
 	stateProof, err := pr.chain.GetProof(
-		context.TODO(),
+		ctx,
 		pr.chain.IBCAddress(),
 		[][]byte{storageKeyHex},
 		big.NewInt(int64(height.GetRevisionHeight())),
@@ -56,8 +56,8 @@ func (pr *Prover) getStateCommitmentProof(path []byte, height exported.Height) (
 	return stateProof.AccountProofRLP, stateProof.StorageProofRLP[0], nil
 }
 
-func (pr *Prover) GetStorageRoot(header *types.Header) (common.Hash, error) {
-	rlpAccountProof, _, err := pr.getAccountProof(header.Number.Uint64())
+func (pr *Prover) GetStorageRoot(ctx context.Context, header *types.Header) (common.Hash, error) {
+	rlpAccountProof, _, err := pr.getAccountProof(ctx, header.Number.Uint64())
 	if err != nil {
 		return common.Hash{}, err
 	}
@@ -174,7 +174,7 @@ func verifyAccount(target *types.Header, accountProof []byte, path common.Addres
 	return &account, nil
 }
 
-func withValidators(headerFn getHeaderFn, height uint64, ethHeaders []*ETHHeader) (core.Header, error) {
+func withValidators(ctx context.Context, headerFn getHeaderFn, height uint64, ethHeaders []*ETHHeader) (core.Header, error) {
 
 	header := &Header{
 		Headers: ethHeaders,
@@ -184,14 +184,14 @@ func withValidators(headerFn getHeaderFn, height uint64, ethHeaders []*ETHHeader
 	previousEpoch := getPreviousEpoch(height)
 	var previousTurnLength uint8
 	var err error
-	header.PreviousValidators, previousTurnLength, err = queryValidatorSetAndTurnLength(context.TODO(), headerFn, previousEpoch)
+	header.PreviousValidators, previousTurnLength, err = queryValidatorSetAndTurnLength(ctx, headerFn, previousEpoch)
 	header.PreviousTurnLength = uint32(previousTurnLength)
 	if err != nil {
 		return nil, fmt.Errorf("ValidatorSet was not found in previous epoch : number = %d : %+v", previousEpoch, err)
 	}
 	currentEpoch := getCurrentEpoch(height)
 	var currentTurnLength uint8
-	header.CurrentValidators, currentTurnLength, err = queryValidatorSetAndTurnLength(context.TODO(), headerFn, currentEpoch)
+	header.CurrentValidators, currentTurnLength, err = queryValidatorSetAndTurnLength(ctx, headerFn, currentEpoch)
 	header.CurrentTurnLength = uint32(currentTurnLength)
 	if err != nil {
 		return nil, fmt.Errorf("ValidatorSet was not found in current epoch : number= %d : %+v", currentEpoch, err)

--- a/module/proof.go
+++ b/module/proof.go
@@ -2,10 +2,12 @@ package module
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"math/big"
+
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/hyperledger-labs/yui-relayer/core"
-	"math/big"
 
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
@@ -18,6 +20,7 @@ import (
 
 func (pr *Prover) getAccountProof(height uint64) ([]byte, common.Hash, error) {
 	stateProof, err := pr.chain.GetProof(
+		context.TODO(),
 		pr.chain.IBCAddress(),
 		nil,
 		big.NewInt(0).SetUint64(height),
@@ -41,6 +44,7 @@ func (pr *Prover) getStateCommitmentProof(path []byte, height exported.Height) (
 
 	// call eth_getProof
 	stateProof, err := pr.chain.GetProof(
+		context.TODO(),
 		pr.chain.IBCAddress(),
 		[][]byte{storageKeyHex},
 		big.NewInt(int64(height.GetRevisionHeight())),

--- a/module/proof.go
+++ b/module/proof.go
@@ -184,14 +184,14 @@ func withValidators(headerFn getHeaderFn, height uint64, ethHeaders []*ETHHeader
 	previousEpoch := getPreviousEpoch(height)
 	var previousTurnLength uint8
 	var err error
-	header.PreviousValidators, previousTurnLength, err = queryValidatorSetAndTurnLength(headerFn, previousEpoch)
+	header.PreviousValidators, previousTurnLength, err = queryValidatorSetAndTurnLength(context.TODO(), headerFn, previousEpoch)
 	header.PreviousTurnLength = uint32(previousTurnLength)
 	if err != nil {
 		return nil, fmt.Errorf("ValidatorSet was not found in previous epoch : number = %d : %+v", previousEpoch, err)
 	}
 	currentEpoch := getCurrentEpoch(height)
 	var currentTurnLength uint8
-	header.CurrentValidators, currentTurnLength, err = queryValidatorSetAndTurnLength(headerFn, currentEpoch)
+	header.CurrentValidators, currentTurnLength, err = queryValidatorSetAndTurnLength(context.TODO(), headerFn, currentEpoch)
 	header.CurrentTurnLength = uint32(currentTurnLength)
 	if err != nil {
 		return nil, fmt.Errorf("ValidatorSet was not found in current epoch : number= %d : %+v", currentEpoch, err)

--- a/module/prover.go
+++ b/module/prover.go
@@ -143,7 +143,7 @@ func (pr *Prover) SetupHeadersForUpdateByLatestHeight(ctx context.Context, clien
 
 func (pr *Prover) ProveState(ctx core.QueryContext, path string, value []byte) ([]byte, clienttypes.Height, error) {
 	proofHeight := toHeight(ctx.Height())
-	accountProof, commitmentProof, err := pr.getStateCommitmentProof([]byte(path), proofHeight)
+	accountProof, commitmentProof, err := pr.getStateCommitmentProof(context.TODO(), []byte(path), proofHeight)
 	if err != nil {
 		return nil, proofHeight, err
 	}
@@ -227,7 +227,7 @@ func (pr *Prover) CheckRefreshRequired(ctx context.Context, counterparty core.Ch
 }
 
 func (pr *Prover) withValidators(height uint64, ethHeaders []*ETHHeader) (core.Header, error) {
-	return withValidators(pr.chain.Header, height, ethHeaders)
+	return withValidators(context.TODO(), pr.chain.Header, height, ethHeaders)
 }
 
 func (pr *Prover) buildInitialState(dstHeader core.Header) (exported.ClientState, exported.ConsensusState, error) {

--- a/module/prover.go
+++ b/module/prover.go
@@ -58,9 +58,9 @@ func (pr *Prover) CreateInitialLightClientState(ctx context.Context, height expo
 	}
 	var finalizedHeader []*ETHHeader
 	if height == nil {
-		_, finalizedHeader, err = queryLatestFinalizedHeader(pr.chain.Header, latestHeight.GetRevisionHeight())
+		_, finalizedHeader, err = queryLatestFinalizedHeader(context.TODO(), pr.chain.Header, latestHeight.GetRevisionHeight())
 	} else {
-		finalizedHeader, err = queryFinalizedHeader(pr.chain.Header, height.GetRevisionHeight(), latestHeight.GetRevisionHeight())
+		finalizedHeader, err = queryFinalizedHeader(context.TODO(), pr.chain.Header, height.GetRevisionHeight(), latestHeight.GetRevisionHeight())
 	}
 	if err != nil {
 		return nil, nil, err
@@ -90,7 +90,7 @@ func (pr *Prover) GetLatestFinalizedHeader(ctx context.Context) (out core.Header
 
 // GetLatestFinalizedHeaderByLatestHeight returns the latest finalized verifiable header from the chain
 func (pr *Prover) GetLatestFinalizedHeaderByLatestHeight(ctx context.Context, latestBlockNumber uint64) (core.Header, error) {
-	height, finalizedHeader, err := queryLatestFinalizedHeader(pr.chain.Header, latestBlockNumber)
+	height, finalizedHeader, err := queryLatestFinalizedHeader(context.TODO(), pr.chain.Header, latestBlockNumber)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 
 func (pr *Prover) SetupHeadersForUpdateByLatestHeight(ctx context.Context, clientStateLatestHeight exported.Height, latestFinalizedHeader *Header) ([]core.Header, error) {
 	queryVerifiableNeighboringEpochHeader := func(height uint64, limitHeight uint64) (core.Header, error) {
-		ethHeaders, err := queryFinalizedHeader(pr.chain.Header, height, limitHeight)
+		ethHeaders, err := queryFinalizedHeader(context.TODO(), pr.chain.Header, height, limitHeight)
 		if err != nil {
 			return nil, err
 		}
@@ -232,13 +232,13 @@ func (pr *Prover) withValidators(height uint64, ethHeaders []*ETHHeader) (core.H
 
 func (pr *Prover) buildInitialState(dstHeader core.Header) (exported.ClientState, exported.ConsensusState, error) {
 	currentEpoch := getCurrentEpoch(dstHeader.GetHeight().GetRevisionHeight())
-	currentValidators, currentTurnLength, err := queryValidatorSetAndTurnLength(pr.chain.Header, currentEpoch)
+	currentValidators, currentTurnLength, err := queryValidatorSetAndTurnLength(context.TODO(), pr.chain.Header, currentEpoch)
 	if err != nil {
 		return nil, nil, err
 	}
 
 	previousEpoch := getPreviousEpoch(dstHeader.GetHeight().GetRevisionHeight())
-	previousValidators, previousTurnLength, err := queryValidatorSetAndTurnLength(pr.chain.Header, previousEpoch)
+	previousValidators, previousTurnLength, err := queryValidatorSetAndTurnLength(context.TODO(), pr.chain.Header, previousEpoch)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/module/prover.go
+++ b/module/prover.go
@@ -118,8 +118,8 @@ func (pr *Prover) SetupHeadersForUpdate(ctx context.Context, counterparty core.F
 }
 
 func (pr *Prover) SetupHeadersForUpdateByLatestHeight(ctx context.Context, clientStateLatestHeight exported.Height, latestFinalizedHeader *Header) ([]core.Header, error) {
-	queryVerifiableNeighboringEpochHeader := func(height uint64, limitHeight uint64) (core.Header, error) {
-		ethHeaders, err := queryFinalizedHeader(context.TODO(), pr.chain.Header, height, limitHeight)
+	queryVerifiableNeighboringEpochHeader := func(ctx context.Context, height uint64, limitHeight uint64) (core.Header, error) {
+		ethHeaders, err := queryFinalizedHeader(ctx, pr.chain.Header, height, limitHeight)
 		if err != nil {
 			return nil, err
 		}
@@ -134,6 +134,7 @@ func (pr *Prover) SetupHeadersForUpdateByLatestHeight(ctx context.Context, clien
 		return nil, err
 	}
 	return setupHeadersForUpdate(
+		context.TODO(),
 		queryVerifiableNeighboringEpochHeader,
 		pr.chain.Header,
 		clientStateLatestHeight,

--- a/module/prover_test.go
+++ b/module/prover_test.go
@@ -156,7 +156,7 @@ func (ts *ProverTestSuite) TestQueryClientStateWithProof() {
 	bzCs, err := ts.prover.chain.Codec().Marshal(cs)
 	ts.Require().NoError(err)
 
-	ctx := core.NewQueryContext(context.TODO(), clienttypes.NewHeight(0, 21400))
+	ctx := core.NewQueryContext(context.Background(), clienttypes.NewHeight(0, 21400))
 	proof, proofHeight, err := ts.prover.ProveState(ctx, host.FullClientStatePath(ts.prover.chain.Path().ClientID), bzCs)
 	ts.Require().NoError(err)
 
@@ -248,6 +248,7 @@ func (ts *ProverTestSuite) TestCheckRefreshRequired() {
 		ts.chain.trustedHeight = 0
 	}()
 
+	ctx := context.Background()
 	now := time.Now()
 	chainHeight := clienttypes.NewHeight(0, 0)
 	csHeight := clienttypes.NewHeight(0, 0)
@@ -255,26 +256,26 @@ func (ts *ProverTestSuite) TestCheckRefreshRequired() {
 
 	// should refresh by trusting_period
 	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-51 * time.Second).UnixNano())
-	required, err := ts.prover.CheckRefreshRequired(context.TODO(), dst)
+	required, err := ts.prover.CheckRefreshRequired(ctx, dst)
 	ts.Require().NoError(err)
 	ts.Require().True(required)
 
 	// needless by trusting_period
 	ts.chain.consensusStateTimestamp[csHeight] = uint64(now.Add(-50 * time.Second).UnixNano())
-	required, err = ts.prover.CheckRefreshRequired(context.TODO(), dst)
+	required, err = ts.prover.CheckRefreshRequired(ctx, dst)
 	ts.Require().NoError(err)
 	ts.Require().False(required)
 
 	// should refresh by block difference
 	ts.chain.latestHeight = 2
 	ts.prover.config.RefreshBlockDifferenceThreshold = 1
-	required, err = ts.prover.CheckRefreshRequired(context.TODO(), dst)
+	required, err = ts.prover.CheckRefreshRequired(ctx, dst)
 	ts.Require().NoError(err)
 	ts.Require().True(required)
 
 	// needless by block difference
 	ts.prover.config.RefreshBlockDifferenceThreshold = 2
-	required, err = ts.prover.CheckRefreshRequired(context.TODO(), dst)
+	required, err = ts.prover.CheckRefreshRequired(ctx, dst)
 	ts.Require().NoError(err)
 	ts.Require().False(required)
 
@@ -282,7 +283,7 @@ func (ts *ProverTestSuite) TestCheckRefreshRequired() {
 	ts.chain.latestHeight = 1
 	ts.chain.trustedHeight = 3
 	ts.prover.config.RefreshBlockDifferenceThreshold = 1
-	required, err = ts.prover.CheckRefreshRequired(context.TODO(), dst)
+	required, err = ts.prover.CheckRefreshRequired(ctx, dst)
 	ts.Require().NoError(err)
 	ts.Require().False(required)
 }
@@ -299,7 +300,7 @@ func (ts *ProverTestSuite) TestProveHostConsensusState() {
 		(*exported.ConsensusState)(nil),
 		&ConsensusState{},
 	)
-	ctx := core.NewQueryContext(context.TODO(), clienttypes.NewHeight(0, 0))
+	ctx := core.NewQueryContext(context.Background(), clienttypes.NewHeight(0, 0))
 	prove, err := ts.prover.ProveHostConsensusState(ctx, clienttypes.NewHeight(0, 0), &cs)
 	ts.Require().NoError(err)
 	ts.Require().Len(prove, 150)

--- a/module/prover_test.go
+++ b/module/prover_test.go
@@ -106,7 +106,7 @@ func (ts *ProverTestSuite) SetupTest() {
 	}
 	anySignerConfig, err := codectypes.NewAnyWithValue(signerConfig)
 	ts.Require().NoError(err)
-	chain, err := ethereum.NewChain(ethereum.ChainConfig{
+	chain, err := ethereum.NewChain(context.Background(), ethereum.ChainConfig{
 		EthChainId: 9999,
 		IbcAddress: common.Address{}.String(),
 		Signer:     anySignerConfig,

--- a/module/prover_test.go
+++ b/module/prover_test.go
@@ -31,7 +31,7 @@ type mockChain struct {
 	trustedHeight           uint64
 }
 
-func (c *mockChain) GetProof(_ common.Address, _ [][]byte, _ *big.Int) (*client.StateProof, error) {
+func (c *mockChain) GetProof(_ context.Context, _ common.Address, _ [][]byte, _ *big.Int) (*client.StateProof, error) {
 	// eth.getProof("0xaa43d337145E8930d01cb4E60Abf6595C692921E",["0x0c0dd47e5867d48cad725de0d09f9549bd564c1d143f6c1f451b26ccd981eeae"], 21400)
 	// storageHash: "0xc3608871098f21b59607ef3fb9412a091de9246ad1281a92f5b07dc2f465b7a0",
 	accountProof := []string{
@@ -166,7 +166,7 @@ func (ts *ProverTestSuite) TestQueryClientStateWithProof() {
 	decoded := ProveState{}
 	ts.Require().NoError(decoded.Unmarshal(proof))
 
-	expected, _ := ts.chain.GetProof(common.Address{}, nil, nil)
+	expected, _ := ts.chain.GetProof(context.Background(), common.Address{}, nil, nil)
 	ts.Require().Equal(common.Bytes2Hex(decoded.AccountProof), common.Bytes2Hex(expected.AccountProofRLP))
 	// storage_key is 0x0c0dd47e5867d48cad725de0d09f9549bd564c1d143f6c1f451b26ccd981eeae
 	ts.Require().Equal(common.Bytes2Hex(decoded.CommitmentProof), "f853f8518080a0143145e818eeff83817419a6632ea193fd1acaa4f791eb17282f623f38117f568080808080808080a016cbf6e0ba10512eb618d99a1e34025adb7e6f31d335bda7fb20c8bb95fb5b978080808080")

--- a/module/setup.go
+++ b/module/setup.go
@@ -1,7 +1,9 @@
 package module
 
 import (
+	"context"
 	"fmt"
+
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/cosmos/ibc-go/v8/modules/core/exported"
 	"github.com/datachainlab/ibc-parlia-relay/module/constant"
@@ -60,7 +62,7 @@ func setupNeighboringEpochHeader(
 	latestHeight exported.Height,
 ) (core.Header, error) {
 	// neighboring epoch needs block before checkpoint
-	currentValidatorSet, currentTurnLength, err := queryValidatorSetAndTurnLength(getHeader, epochHeight)
+	currentValidatorSet, currentTurnLength, err := queryValidatorSetAndTurnLength(context.TODO(), getHeader, epochHeight)
 	if err != nil {
 		return nil, fmt.Errorf("setupNeighboringEpochHeader: failed to get current validator set: epochHeight=%d : %+v", epochHeight, err)
 	}

--- a/module/setup_test.go
+++ b/module/setup_test.go
@@ -2,14 +2,15 @@ package module
 
 import (
 	"context"
+	"math/big"
+	"testing"
+
 	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/datachainlab/ibc-parlia-relay/module/constant"
 	types2 "github.com/ethereum/go-ethereum/core/types"
 	"github.com/hyperledger-labs/yui-relayer/core"
 	"github.com/hyperledger-labs/yui-relayer/log"
 	"github.com/stretchr/testify/suite"
-	"math/big"
-	"testing"
 )
 
 type SetupTestSuite struct {
@@ -38,7 +39,7 @@ func (ts *SetupTestSuite) TestSuccess_setupHeadersForUpdate_neighboringEpoch() {
 			CurrentValidators:  [][]byte{{1}},
 			PreviousValidators: [][]byte{{1}},
 		}
-		neighborFn := func(height uint64, _ uint64) (core.Header, error) {
+		neighborFn := func(_ context.Context, height uint64, _ uint64) (core.Header, error) {
 			h, e := newETHHeader(&types2.Header{
 				Number: big.NewInt(int64(height)),
 			})
@@ -53,7 +54,7 @@ func (ts *SetupTestSuite) TestSuccess_setupHeadersForUpdate_neighboringEpoch() {
 			}, nil
 		}
 
-		targets, err := setupHeadersForUpdate(neighborFn, headerFn, clientStateLatestHeight, latestFinalizedHeader, clienttypes.NewHeight(0, 100000))
+		targets, err := setupHeadersForUpdate(context.Background(), neighborFn, headerFn, clientStateLatestHeight, latestFinalizedHeader, clienttypes.NewHeight(0, 100000))
 		ts.Require().NoError(err)
 		ts.Require().Len(targets, expected)
 		for i, h := range targets {
@@ -101,7 +102,7 @@ func (ts *SetupTestSuite) TestSuccess_setupHeadersForUpdate_allEmpty() {
 		latestFinalizedHeader := &Header{
 			Headers: []*ETHHeader{target},
 		}
-		neighboringEpochFn := func(height uint64, _ uint64) (core.Header, error) {
+		neighboringEpochFn := func(_ context.Context, height uint64, _ uint64) (core.Header, error) {
 			// insufficient vote attestation
 			return nil, nil
 		}
@@ -111,7 +112,7 @@ func (ts *SetupTestSuite) TestSuccess_setupHeadersForUpdate_allEmpty() {
 				Extra:  epochHeader().Extra,
 			}, nil
 		}
-		targets, err := setupHeadersForUpdate(neighboringEpochFn, headerFn, clientStateLatestHeight, latestFinalizedHeader, clienttypes.NewHeight(0, 1000000))
+		targets, err := setupHeadersForUpdate(context.Background(), neighboringEpochFn, headerFn, clientStateLatestHeight, latestFinalizedHeader, clienttypes.NewHeight(0, 1000000))
 		ts.Require().NoError(err)
 		ts.Require().Len(targets, expected)
 	}
@@ -144,7 +145,7 @@ func (ts *SetupTestSuite) TestSuccess_setupNeighboringEpochHeader() {
 	epochHeight := uint64(400)
 	trustedEpochHeight := uint64(200)
 
-	neighboringEpochFn := func(height uint64, limit uint64) (core.Header, error) {
+	neighboringEpochFn := func(_ context.Context, height uint64, limit uint64) (core.Header, error) {
 		target, err := newETHHeader(&types2.Header{
 			Number: big.NewInt(int64(limit)),
 		})
@@ -156,7 +157,7 @@ func (ts *SetupTestSuite) TestSuccess_setupNeighboringEpochHeader() {
 	headerFn := func(_ context.Context, height uint64) (*types2.Header, error) {
 		return headerByHeight(int64(height)), nil
 	}
-	hs, err := setupNeighboringEpochHeader(headerFn, neighboringEpochFn, epochHeight, trustedEpochHeight, clienttypes.NewHeight(0, 10000))
+	hs, err := setupNeighboringEpochHeader(context.Background(), headerFn, neighboringEpochFn, epochHeight, trustedEpochHeight, clienttypes.NewHeight(0, 10000))
 	ts.Require().NoError(err)
 	target, err := hs.(*Header).Target()
 	ts.Require().NoError(err)

--- a/module/validator_set.go
+++ b/module/validator_set.go
@@ -3,6 +3,7 @@ package module
 import (
 	"context"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
@@ -12,8 +13,8 @@ func (v Validators) Checkpoint(turnLength uint8) uint64 {
 	return uint64(len(v)/2+1) * uint64(turnLength)
 }
 
-func queryValidatorSetAndTurnLength(fn getHeaderFn, epochBlockNumber uint64) (Validators, uint8, error) {
-	header, err := fn(context.TODO(), epochBlockNumber)
+func queryValidatorSetAndTurnLength(ctx context.Context, fn getHeaderFn, epochBlockNumber uint64) (Validators, uint8, error) {
+	header, err := fn(ctx, epochBlockNumber)
 	if err != nil {
 		return nil, 1, err
 	}

--- a/module/validator_set_test.go
+++ b/module/validator_set_test.go
@@ -3,10 +3,11 @@ package module
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/stretchr/testify/suite"
 	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/suite"
 )
 
 type ValidatorSetTestSuite struct {
@@ -54,7 +55,7 @@ func (ts *ValidatorSetTestSuite) TestSuccessQueryValidatorSet() {
 	fn := func(ctx context.Context, height uint64) (*types.Header, error) {
 		return epochHeader(), nil
 	}
-	validators, turnLength, err := QueryValidatorSetAndTurnLength(fn, 400)
+	validators, turnLength, err := QueryValidatorSetAndTurnLength(context.Background(), fn, 400)
 	ts.Require().NoError(err)
 	ts.Require().Len(validators, 4)
 	ts.Require().Equal(turnLength, uint8(1))
@@ -64,7 +65,7 @@ func (ts *ValidatorSetTestSuite) TestErrorQueryValidatorSet() {
 	fn := func(ctx context.Context, height uint64) (*types.Header, error) {
 		return nil, errors.New("error")
 	}
-	_, _, err := QueryValidatorSetAndTurnLength(fn, 200)
+	_, _, err := QueryValidatorSetAndTurnLength(context.Background(), fn, 200)
 	ts.Require().Equal(err.Error(), "error")
 }
 

--- a/tool/testdata/internal/common.go
+++ b/tool/testdata/internal/common.go
@@ -1,14 +1,16 @@
 package internal
 
 import (
+	"context"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/datachainlab/ethereum-ibc-relay-chain/pkg/relay/ethereum"
 	"github.com/datachainlab/ibc-hd-signer/pkg/hd"
 	"github.com/datachainlab/ibc-parlia-relay/module"
 	"github.com/spf13/viper"
-	"os"
-	"time"
 )
 
 const (
@@ -36,12 +38,12 @@ func CreateSignerConfig() *types.Any {
 	return anySignerConfig
 }
 
-func createProver() (*module.Prover, module.Chain, error) {
+func createProver(ctx context.Context) (*module.Prover, module.Chain, error) {
 	rpcAddr, err := createRPCAddr()
 	if err != nil {
 		return nil, nil, err
 	}
-	chain, err := ethereum.NewChain(ethereum.ChainConfig{
+	chain, err := ethereum.NewChain(ctx, ethereum.ChainConfig{
 		EthChainId: 9999,
 		RpcAddr:    rpcAddr,
 		Signer:     CreateSignerConfig(),

--- a/tool/testdata/internal/create_client.go
+++ b/tool/testdata/internal/create_client.go
@@ -1,12 +1,13 @@
 package internal
 
 import (
+	"log"
+
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/gogoproto/proto"
 	"github.com/datachainlab/ibc-parlia-relay/module"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 type createClientModule struct {
@@ -16,11 +17,11 @@ func (m *createClientModule) createClientSuccessCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use: "success",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			prover, chain, err := createProver()
+			prover, chain, err := createProver(cmd.Context())
 			if err != nil {
 				return err
 			}
-			cs, consState, err := prover.CreateInitialLightClientState(nil)
+			cs, consState, err := prover.CreateInitialLightClientState(cmd.Context(), nil)
 			if err != nil {
 				return err
 			}
@@ -41,11 +42,11 @@ func (m *createClientModule) createClientSuccessCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			currentValidatorSet, currentTurnLength, err := module.QueryValidatorSetAndTurnLength(chain.Header, module.GetCurrentEpoch(cs.GetLatestHeight().GetRevisionHeight()))
+			currentValidatorSet, currentTurnLength, err := module.QueryValidatorSetAndTurnLength(cmd.Context(), chain.Header, module.GetCurrentEpoch(cs.GetLatestHeight().GetRevisionHeight()))
 			if err != nil {
 				return err
 			}
-			previousValidatorSet, previousTurnLength, err := module.QueryValidatorSetAndTurnLength(chain.Header, module.GetPreviousEpoch(cs.GetLatestHeight().GetRevisionHeight()))
+			previousValidatorSet, previousTurnLength, err := module.QueryValidatorSetAndTurnLength(cmd.Context(), chain.Header, module.GetPreviousEpoch(cs.GetLatestHeight().GetRevisionHeight()))
 			if err != nil {
 				return err
 			}

--- a/tool/testdata/internal/header.go
+++ b/tool/testdata/internal/header.go
@@ -2,13 +2,14 @@ package internal
 
 import (
 	"context"
+	"log"
+
 	"github.com/datachainlab/ibc-parlia-relay/module"
 	"github.com/datachainlab/ibc-parlia-relay/module/constant"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
-	"log"
 )
 
 type headerModule struct {
@@ -21,11 +22,11 @@ func (m *headerModule) success() *cobra.Command {
 	cmd.AddCommand(&cobra.Command{
 		Use: "latest",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, chain, err := createProver()
+			_, chain, err := createProver(cmd.Context())
 			if err != nil {
 				return err
 			}
-			latest, err := chain.LatestHeight()
+			latest, err := chain.LatestHeight(cmd.Context())
 			if err != nil {
 				return err
 			}
@@ -37,7 +38,7 @@ func (m *headerModule) success() *cobra.Command {
 	specified := &cobra.Command{
 		Use: "specified",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			_, chain, err := createProver()
+			_, chain, err := createProver(cmd.Context())
 			if err != nil {
 				return err
 			}

--- a/tool/testdata/internal/membership/verify_membership.go
+++ b/tool/testdata/internal/membership/verify_membership.go
@@ -2,6 +2,10 @@ package membership
 
 import (
 	"context"
+	"log"
+	"math/big"
+	"os"
+
 	"github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	conntypes "github.com/cosmos/ibc-go/v8/modules/core/03-connection/types"
 	types3 "github.com/cosmos/ibc-go/v8/modules/core/23-commitment/types"
@@ -12,9 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/hyperledger-labs/yui-relayer/core"
 	"github.com/spf13/cobra"
-	"log"
-	"math/big"
-	"os"
 )
 
 type verifyMembershipModule struct {
@@ -89,7 +90,7 @@ func (m *verifyMembershipModule) proveState(chainID uint64, path string, value [
 	}
 
 	proof, proofHeight, err := prover.ProveState(ctx, path, value)
-	storageRoot, err := prover.GetStorageRoot(header)
+	storageRoot, err := prover.GetStorageRoot(context.TODO(), header)
 	if err != nil {
 		return common.Hash{}, nil, types.Height{}, err
 	}

--- a/tool/testdata/internal/membership/verify_membership.go
+++ b/tool/testdata/internal/membership/verify_membership.go
@@ -90,7 +90,7 @@ func (m *verifyMembershipModule) proveState(chainID uint64, path string, value [
 	}
 
 	proof, proofHeight, err := prover.ProveState(ctx, path, value)
-	storageRoot, err := prover.GetStorageRoot(context.TODO(), header)
+	storageRoot, err := prover.GetStorageRoot(ctx.Context(), header)
 	if err != nil {
 		return common.Hash{}, nil, types.Height{}, err
 	}


### PR DESCRIPTION
This is the subsequent PR of https://github.com/datachainlab/ibc-parlia-relay/pull/51 and replaces `context.TODO()` with an appropriate context. 