### PR TITLE
Stabilize e2e

### DIFF
--- a/e2e/chains/bsc/Makefile
+++ b/e2e/chains/bsc/Makefile
@@ -10,6 +10,7 @@ bootstrap:
 
 .PHONY:network
 network:
+	docker compose -f docker-compose.simple.yml up -d autoheal
 	docker compose -f docker-compose.simple.yml up -d bsc-rpc bsc-validator1-1 bsc-validator1-2 bsc-validator1-3  bsc-validator1-4 bsc-validator1-5
 	docker compose -f docker-compose.simple.yml up -d bsc-rpc2 bsc-validator2-1 bsc-validator2-2 bsc-validator2-3
 

--- a/e2e/chains/bsc/docker-compose.simple.yml
+++ b/e2e/chains/bsc/docker-compose.simple.yml
@@ -71,6 +71,10 @@ services:
       - ./scripts:/scripts
       - ./config:/config
     command: ash /scripts/bsc-rpc.sh
+    healthcheck:
+      test: ["CMD", "ash", "/scripts/healthcheck.sh"]
+      interval: "5s"
+      start_period: "10s"
 
   bsc-rpc2: # This is the bootstrap node
     image: bsc-geth:docker-local
@@ -86,6 +90,10 @@ services:
       - ./scripts:/scripts
       - ./config:/config
     command: ash /scripts/bsc-rpc.sh
+    healthcheck:
+      test: ["CMD", "ash", "/scripts/healthcheck.sh"]
+      interval: "5s"
+      start_period: "10s"
 
   bsc-validator1-1:
     image: bsc-geth:docker-local
@@ -216,6 +224,14 @@ services:
       - bsc-validator2-5:/root/.ethereum
       - ./scripts:/scripts
     command: ash /scripts/bsc-validator.sh
+
+  autoheal:
+    restart: always
+    image: willfarrell/autoheal
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 
 networks:
   bsc:

--- a/e2e/chains/bsc/scripts/bootstrap.sh
+++ b/e2e/chains/bsc/scripts/bootstrap.sh
@@ -21,12 +21,12 @@ function init_validator() {
   # set validator address
   mkdir -p ${workspace}/storage/${node_id}/keystore
   cp ${workspace}/validators/keystore/${node_id} ${workspace}/storage/${node_id}/keystore/${node_id}
-  validatorAddr=0x$(cat ${workspace}/storage/${node_id}/keystore/${node_id} | jq .address | sed 's/"//g')
+  validatorAddr=0x$(jq -r .address ${workspace}/storage/${node_id}/keystore/${node_id})
   echo ${validatorAddr} >${workspace}/storage/${node_id}/address
 
   # create new BLS vote address
   expect ${workspace}/scripts/create_bls_key.sh ${workspace}/storage/${node_id}
-  voteAddr=0x$(cat ${workspace}/storage/${node_id}/bls/keystore/*json| jq .pubkey | sed 's/"//g')
+  voteAddr=0x$(jq -r .pubkey ${workspace}/storage/${node_id}/bls/keystore/*json)
   echo $voteAddr
 
   echo "${validatorAddr},${validatorAddr},${validatorAddr},0x0000000010000000,${voteAddr}" >>scripts/validators.conf

--- a/e2e/chains/bsc/scripts/bsc-rpc.sh
+++ b/e2e/chains/bsc/scripts/bsc-rpc.sh
@@ -13,6 +13,7 @@ while [ "$i" -lt ${account_cnt} ]; do
 done
 
 ETHSTATS=""
-geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
+# Use exec to handle signals
+exec geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
 	--state.scheme=hash --db.engine=leveldb --verbosity ${VERBOSE} --nousb ${ETHSTATS} \
 	--unlock ${unlock_sequences} --password /dev/null --ipcpath /gethipc --override.fixedturnlength 2

--- a/e2e/chains/bsc/scripts/bsc-validator.sh
+++ b/e2e/chains/bsc/scripts/bsc-validator.sh
@@ -10,7 +10,8 @@ HOST_IP=$(hostname -i)
 echo "validator id: ${HOST_IP}"
 
 ETHSTATS=""
-geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
+# Use exec to handle signals
+exec geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
 	--verbosity ${VERBOSE} --nousb ${ETHSTATS} --state.scheme=hash --db.engine=leveldb \
 	--bootnodes enode://${BOOTSTRAP_PUB_KEY}@${BOOTSTRAP_IP}:${BOOTSTRAP_TCP_PORT} \
 	--mine --miner.etherbase=${VALIDATOR_ADDR} -unlock ${VALIDATOR_ADDR} --password /dev/null --blspassword /scripts/wallet_password.txt \

--- a/e2e/chains/bsc/scripts/healthcheck.sh
+++ b/e2e/chains/bsc/scripts/healthcheck.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+timestamp=$(geth attach --exec 'parseInt(eth.getBlockByNumber("latest").timestamp)' /gethipc)
+[ $(($(date '+%s') - $timestamp)) -lt 5 ]


### PR DESCRIPTION
This PR resolves the following CI failures as you can see in the PR https://github.com/datachainlab/ibc-parlia-relay/pull/64.
As a rule of thumb, they seems to be caused by unhealthy geth processes, so I have added health checks and a [autoheal](https://hub.docker.com/r/willfarrell/autoheal/) container to automatically restart containers where such a process is running.

## ProviderError: transaction indexing is in progress

![image](https://github.com/user-attachments/assets/9e609027-29a7-4491-8ead-fd2be3c07a15)

## IBCClient deployment gets stuck

![image](https://github.com/user-attachments/assets/0ce5295c-c81a-4e5e-bed5-0f25970e3650)
