### PR TITLE
Expand skip count

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,9 @@ jobs:
         run: |
           make chain
           make contracts
-          # epoch is 200, 400, 500, 1000
-          # Since we want the previous epoch to be before HF we wait for 800 block (0.75sec * 800)
-          sleep 600
+          # Wait for Maxwell HF to be enabled (0.75sec * 2000)
+          sleep 1500
           make relayer
           make test
       - name: integration-test
-        run: go test -v ./tests -tags dev -ldflags="-X github.com/datachainlab/ibc-parlia-relay/module/constant.blocksPerEpoch=20"
+        run: go test -v ./tests

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ![CI](https://github.com/datachainlab/ibc-parlia-relay/workflows/CI/badge.svg?branch=main)
 
 ## Supported Versions
-- [yui-relayer v0.5.11](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.11)
-- [ethereum-ibc-relay-chain v0.3.17](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.3.7)
+- [yui-relayer v0.5.16](https://github.com/hyperledger-labs/yui-relayer/releases/tag/v0.5.16)
+- [ethereum-ibc-relay-chain v0.3.17](https://github.com/datachainlab/ethereum-ibc-relay-chain/releases/tag/v0.3.17)
 - [parlia-elc v0.3.10](https://github.com/datachainlab/parlia-elc/releases/tag/v0.3.10)
 
 ## Setup Relayer

--- a/module/setup.go
+++ b/module/setup.go
@@ -11,7 +11,8 @@ import (
 )
 
 // Maximum header interval to be submitted to LCP
-const skip = 100
+// Supports after Maxwell HF only
+const skip = 1000
 
 type queryVerifiableNeighboringEpochHeaderFn = func(context.Context, uint64, uint64) (core.Header, error)
 


### PR DESCRIPTION
Update_client is currently executed every 100 blocks at most because the HFs with LorentzHF MaxwellHF and epoch length changes.
(This is because the epoch used to switch with a minimum of 100, for example, after 400, 500 became the epoch.)

Currently, the epoch length is 1000 because the Maxwell HF was also applied in the mainnet. The gas cost is reduced and processing speed is increased by changing from 100 to 1000 blocks.

This PR will change the block count from 100 to 1000.
