### PR TITLE
Use bsc 1.6.1-x for e2e

### DIFF
--- a/e2e/chains/bsc/docker-compose.bsc.yml
+++ b/e2e/chains/bsc/docker-compose.bsc.yml
@@ -5,5 +5,5 @@ services:
       dockerfile: Dockerfile.bsc
       args:
         GIT_SOURCE: https://github.com/bnb-chain/bsc
-        GIT_CHECKOUT_BRANCH: v1.5.19-feature-SI
+        GIT_CHECKOUT_BRANCH: v1.6.0-alpha
     image: bsc-geth:docker-local

--- a/e2e/chains/bsc/docker-compose.bsc.yml
+++ b/e2e/chains/bsc/docker-compose.bsc.yml
@@ -5,5 +5,5 @@ services:
       dockerfile: Dockerfile.bsc
       args:
         GIT_SOURCE: https://github.com/bnb-chain/bsc
-        GIT_CHECKOUT_BRANCH: v1.6.0-alpha
+        GIT_CHECKOUT_BRANCH: v1.6.1-beta-feature-ScalableDB
     image: bsc-geth:docker-local

--- a/e2e/chains/bsc/scripts/bootstrap.sh
+++ b/e2e/chains/bsc/scripts/bootstrap.sh
@@ -25,7 +25,7 @@ function init_validator() {
   echo ${validatorAddr} >${workspace}/storage/${node_id}/address
 
   # create new BLS vote address
-  expect ${workspace}/scripts/create_bls_key.sh ${workspace}/storage/${node_id}
+  ${workspace}/scripts/create_bls_key.sh ${workspace}/storage/${node_id} ${workspace}/scripts/wallet_password.txt
   voteAddr=0x$(jq -r .pubkey ${workspace}/storage/${node_id}/bls/keystore/*json)
   echo $voteAddr
 

--- a/e2e/chains/bsc/scripts/bsc-rpc.sh
+++ b/e2e/chains/bsc/scripts/bsc-rpc.sh
@@ -12,8 +12,10 @@ while [ "$i" -lt ${account_cnt} ]; do
 	i=$((i + 1))
 done
 
+HOST_IP=$(hostname -i)
+
 ETHSTATS=""
 # Use exec to handle signals
 exec geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict ${CLUSTER_CIDR} \
 	--state.scheme=hash --db.engine=leveldb --verbosity ${VERBOSE} --nousb ${ETHSTATS} \
-	--unlock ${unlock_sequences} --password /dev/null --ipcpath /gethipc --override.fixedturnlength 2
+	--unlock ${unlock_sequences} --password /dev/null --ipcpath /gethipc --override.fixedturnlength 2 -nat extip:${HOST_IP}

--- a/e2e/chains/bsc/scripts/bsc-validator.sh
+++ b/e2e/chains/bsc/scripts/bsc-validator.sh
@@ -15,6 +15,6 @@ exec geth --config ${DATA_DIR}/config.toml --datadir ${DATA_DIR} --netrestrict $
 	--verbosity ${VERBOSE} --nousb ${ETHSTATS} --state.scheme=hash --db.engine=leveldb \
 	--bootnodes enode://${BOOTSTRAP_PUB_KEY}@${BOOTSTRAP_IP}:${BOOTSTRAP_TCP_PORT} \
 	--mine --miner.etherbase=${VALIDATOR_ADDR} -unlock ${VALIDATOR_ADDR} --password /dev/null --blspassword /scripts/wallet_password.txt \
-	--light.serve 50 --pprof.addr 0.0.0.0 --metrics \
+	--pprof.addr 0.0.0.0 --metrics \
 	--rpc.allow-unprotected-txs  --history.transactions 15768000 \
-	--pprof --ipcpath /gethipc --vote --override.fixedturnlength 2
+	--pprof --ipcpath /gethipc --vote --override.fixedturnlength 2 --nat extip:${HOST_IP}

--- a/e2e/chains/bsc/scripts/create_bls_key.sh
+++ b/e2e/chains/bsc/scripts/create_bls_key.sh
@@ -1,12 +1,3 @@
-#!/usr/bin/expect
-# 10 characters at least wanted
-set wallet_password 1234567890
+#!/usr/bin/bash
 
-set timeout 5
-sleep 10
-spawn geth bls account new --datadir [lindex $argv 0]
-expect "*assword:*"
-send "$wallet_password\r"
-expect "*assword:*"
-send "$wallet_password\r"
-expect EOF
+geth bls account new --datadir $1 --blspassword $2


### PR DESCRIPTION
* Bump bsc to v1.6.1-beta-feature-ScalableDB
   - We need to use --nat in docker enviromnent after bsc 1.6.0-alpha
   - We can use --blspassword option to create bls account